### PR TITLE
Fix transf matrix getters to use corrected pose

### DIFF
--- a/open_constructor/app/src/main/jni/mesh_builder_app.cc
+++ b/open_constructor/app/src/main/jni/mesh_builder_app.cc
@@ -56,7 +56,7 @@ namespace mesh_builder {
 
         TangoMatrixTransformData matrix_transform;
         TangoSupport_getMatrixTransformAtTime(
-                point_cloud->timestamp, TANGO_COORDINATE_FRAME_START_OF_SERVICE,
+                point_cloud->timestamp, TANGO_COORDINATE_FRAME_AREA_DESCRIPTION,
                 TANGO_COORDINATE_FRAME_CAMERA_DEPTH, TANGO_SUPPORT_ENGINE_OPENGL,
                 TANGO_SUPPORT_ENGINE_TANGO, ROTATION_0, &matrix_transform);
         if (matrix_transform.status_code != TANGO_POSE_VALID)
@@ -85,7 +85,7 @@ namespace mesh_builder {
 
         TangoMatrixTransformData matrix_transform;
         TangoSupport_getMatrixTransformAtTime(
-                        buffer->timestamp, TANGO_COORDINATE_FRAME_START_OF_SERVICE,
+                        buffer->timestamp, TANGO_COORDINATE_FRAME_AREA_DESCRIPTION,
                         TANGO_COORDINATE_FRAME_CAMERA_COLOR, TANGO_SUPPORT_ENGINE_OPENGL,
                         TANGO_SUPPORT_ENGINE_TANGO, ROTATION_0, &matrix_transform);
         if (matrix_transform.status_code != TANGO_POSE_VALID)
@@ -399,7 +399,7 @@ namespace mesh_builder {
         } else {
             TangoMatrixTransformData matrix_transform;
             TangoSupport_getMatrixTransformAtTime(
-                    0, TANGO_COORDINATE_FRAME_START_OF_SERVICE, TANGO_COORDINATE_FRAME_DEVICE,
+                    0, TANGO_COORDINATE_FRAME_AREA_DESCRIPTION, TANGO_COORDINATE_FRAME_DEVICE,
                     TANGO_SUPPORT_ENGINE_OPENGL, TANGO_SUPPORT_ENGINE_OPENGL,
                     landscape ? ROTATION_90 : ROTATION_0, &matrix_transform);
             glm::mat4 start_service_T_device_;


### PR DESCRIPTION
Hello!

This is a simple fix to use the 'corrected' pose information during reconstructions. The Tango config is currently set with "config_enable_drift_correction" to true, but unless "TANGO_COORDINATE_FRAME_AREA_DESCRIPTION" is used as the base reference in "TangoSupport_getMatrixTransformAtTime" calls, the pose will not be corrected.

I just rebased this patch over the latest commits, but it was tested last week over de69e911343c24d2b6e1b1b191193804fb48b05b.